### PR TITLE
docs(storybook): add sectionTitle configs to move components easily

### DIFF
--- a/packages/automation/config.js
+++ b/packages/automation/config.js
@@ -5,10 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
-
-export const Default = () => <>Story</>;
-
-export default {
-  title: 'CD&AI/Story',
-};
+export const sectionTitle = 'Automation';

--- a/packages/automation/src/Dummy/Dummy.stories.js
+++ b/packages/automation/src/Dummy/Dummy.stories.js
@@ -7,8 +7,10 @@
 
 import React from 'react';
 
-export const Default = () => <>Story</>;
+import { sectionTitle } from '../../config';
+
+export const Default = () => <>Dummy Story</>;
 
 export default {
-  title: 'Automation/Story',
+  title: `${sectionTitle}/Dummy`,
 };

--- a/packages/cdai/config.js
+++ b/packages/cdai/config.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const sectionTitle = 'CD&AI';

--- a/packages/cdai/src/Dummy/Dummy.stories.js
+++ b/packages/cdai/src/Dummy/Dummy.stories.js
@@ -7,8 +7,10 @@
 
 import React from 'react';
 
-export const Default = () => <>Story</>;
+import { sectionTitle } from '../../config';
+
+export const Default = () => <>Dummy Story</>;
 
 export default {
-  title: 'Common Services/Story',
+  title: `${sectionTitle}/Dummy`,
 };

--- a/packages/common-services/config.js
+++ b/packages/common-services/config.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const sectionTitle = 'Common Services';

--- a/packages/common-services/src/Dummy/Dummy.stories.js
+++ b/packages/common-services/src/Dummy/Dummy.stories.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+import { sectionTitle } from '../../config';
+
+export const Default = () => <>Dummy Story</>;
+
+export default {
+  title: `${sectionTitle}/Dummy`,
+};

--- a/packages/security/config.js
+++ b/packages/security/config.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright IBM Corp. 2020, 2020
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const sectionTitle = 'Security';

--- a/packages/security/src/ComboButton/ComboButton.stories.js
+++ b/packages/security/src/ComboButton/ComboButton.stories.js
@@ -9,6 +9,8 @@ import { action } from '@storybook/addon-actions';
 import { text } from '@storybook/addon-knobs';
 import React from 'react';
 
+import { sectionTitle } from '../../config';
+
 import { ComboButton, ComboButtonItem } from '..';
 import './_index.scss';
 
@@ -22,6 +24,6 @@ export const Default = () => (
 );
 
 export default {
-  title: 'Security/ComboButton',
+  title: `${sectionTitle}/ComboButton`,
   component: ComboButton,
 };


### PR DESCRIPTION
#### Changelog

**New**

- add `sectionTitle` in `packages/<section>/config.js`

**Changed**

- replaced hardcoded section titles with the string from the config
- moved dummy stories into dummy component folders