### PR TITLE
Make PageHeader stories scrollable to demo header collapse

### DIFF
--- a/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
@@ -30,6 +30,13 @@ export default {
   title: 'Experimental/PageHeader',
   component: PageHeader,
   parameters: { styles, layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="page-header-stories__viewport">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 // Test values for props.

--- a/packages/experimental-package/src/components/PageHeader/PageHeaderCopy.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageHeaderCopy.stories.js
@@ -28,6 +28,13 @@ export default {
   title: 'Experimental/PageHeaderCopy',
   component: PageHeader,
   parameters: { styles, layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="page-header-stories__viewport">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 const breadcrumbItems = (

--- a/packages/experimental-package/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/experimental-package/src/components/PageHeader/_storybook-styles.scss
@@ -11,22 +11,9 @@
 @import 'carbon-components/scss/components/tabs/tabs';
 @import 'carbon-components/scss/components/tag/tag';
 
-.page-header-stories__status-icon {
-  vertical-align: middle;
-  fill: $support-02;
-}
-
-.container {
-  height: 100vh;
-}
-
-.content {
-  width: 0;
-  height: 0;
-  margin-left: 5vw;
-  border-right: 45vw solid transparent;
-  border-bottom: 150vh solid $support-03;
-  border-left: 45vw solid transparent;
+.page-header-stories__viewport {
+  max-height: 500px;
+  overflow-y: scroll;
 }
 
 .page-header-stories__dummy-content {
@@ -34,11 +21,16 @@
 }
 
 .page-header-stories__dummy-content-block {
-  height: 60px;
+  height: 600px;
   background: $ui-01;
   background-clip: content-box;
 }
 
 .page-header-stories__dummy-content-text {
   padding: $spacing-05;
+}
+
+.page-header-stories__status-icon {
+  vertical-align: middle;
+  fill: $support-02;
 }

--- a/packages/experimental-package/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/experimental-package/src/components/PageHeader/_storybook-styles.scss
@@ -11,9 +11,9 @@
 @import 'carbon-components/scss/components/tabs/tabs';
 @import 'carbon-components/scss/components/tag/tag';
 
-.page-header-stories__viewport {
+.sbdocs .page-header-stories__viewport {
+  overflow-y: auto;
   max-height: 500px;
-  overflow-y: scroll;
 }
 
 .page-header-stories__dummy-content {
@@ -21,7 +21,7 @@
 }
 
 .page-header-stories__dummy-content-block {
-  height: 600px;
+  height: 120vh;
   background: $ui-01;
   background-clip: content-box;
 }
@@ -33,4 +33,13 @@
 .page-header-stories__status-icon {
   vertical-align: middle;
   fill: $support-02;
+}
+
+.content {
+  width: 0;
+  height: 0;
+  margin-left: 5vw;
+  border-right: 45vw solid transparent;
+  border-bottom: 150vh solid $support-03;
+  border-left: 45vw solid transparent;
 }


### PR DESCRIPTION
Makes all the stories for the PageHeader component scrollable, to demo the header collapse functionality.

#### Changelog

M       packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
M       packages/experimental-package/src/components/PageHeader/PageHeaderCopy.stories.js
M       packages/experimental-package/src/components/PageHeader/_storybook-styles.scss