### PR TITLE
First pass at docs page for PageHeader component

### DIFF
--- a/packages/core/.storybook/addon-carbon-theme/components/Panel.js
+++ b/packages/core/.storybook/addon-carbon-theme/components/Panel.js
@@ -40,7 +40,7 @@ const typeTokenDefaults = {
  * Storybook add-on panel for Carbon theme switcher.
  */
 export const CarbonThemesPanel = ({ api, active }) => {
-  const [currentTheme, setCurrentTheme] = useState('white');
+  const [currentTheme, setCurrentTheme] = useState('g10');
   const handleChange = useCallback(
     (event) => {
       const { value } = event.target;
@@ -49,6 +49,7 @@ export const CarbonThemesPanel = ({ api, active }) => {
     },
     [api]
   );
+  api.getChannel().emit(CARBON_CURRENT_THEME, currentTheme);
   return (
     active && (
       <Form>

--- a/packages/experimental-package/src/components/PageHeader/PageHeader.mdx
+++ b/packages/experimental-package/src/components/PageHeader/PageHeader.mdx
@@ -1,0 +1,154 @@
+import { Story, Props, Source, Preview } from '@storybook/addon-docs/blocks';
+import { Pageheader } from './PageHeader';
+
+# PageHeader
+
+## Anatomy
+
+The page header is comprised of 6 zones, allowing for the flexibility to include
+(or exclude) areas depending on the context and needs of the page.
+
+![image](https://user-images.githubusercontent.com/50155706/93520637-69dcad00-f8f4-11ea-8d2a-d56c90beb0b4.png)
+
+1. **Breadcrumbs:** This zone is for the breadcrumb component to be displayed.
+   Breadcrumbs should typically be displayed if there are navigable pages that
+   precede the current page.
+2. **Page title:** This zone is for a page title to be displayed. Optionally an
+   icon can be included to the left of the title text.
+3. **Subtitle / description (optional):** This zone is for the inclusion of a
+   subtitle or description to provide additional context to identify the current
+   page.
+4. **Available space (optional):** This zone is for placing high-level content
+   above page tabs.
+5. **Tabs (optional):** This zone is for placing navigation within a page. e.g.
+   tabs, content switcher etc.
+6. **Actions (optional):** This zone is for placing critical page actions.
+
+## Main types
+
+### Page header without background
+
+The simplest expression of the page header. A background-less page header should
+be used if only the breadcrumb, title, actions, and/or simple status are
+required.
+
+<Preview>
+  <Story id="experimental-pageheader--without-background-breadcrumbitems-title-pageactions" />
+</Preview>
+
+### Page header with background
+
+The more complex expression of the page header. The background provides
+structurality and aids in establishing hierarchy for page headers with more
+items. The page header with a background should be used if tabs, subtitles,
+and/or more global items are required.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-title-pageactions-tabs" />
+</Preview>
+
+### Page header with background (breadcrumb + actions toolbar included)
+
+If the page header contains action icons, the default state includes a toolbar
+designated for the breadcrumbs and action icons.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-actionbar-title-pageactions-tabs-tags" />
+</Preview>
+
+### Page header with background (breadcrumb + actions toolbar ONLY)
+
+On occasion, a condensed page header is required. This version accommodates this
+by just displaying the breadcrumb bar only.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-actionbar" />
+</Preview>
+
+## Examples
+
+The page header allows for the flexibility to additively contain both type and
+components with predictable spacing in the overall layout.
+
+### Examples without background
+
+#### Page title only
+
+This is the base of the page header, establishing spacing/title structure that
+all other sans background page headers follow. The base is best used to
+accommodate simple requirements, including page title only, or page title +
+buttons.
+
+<Preview>
+  <Story id="experimental-pageheader--without-background-title-only" />
+</Preview>
+
+#### With breadcrumbs
+
+This variant of the page header accounts for page title, buttons, breadcrumbs,
+and occasionally icons and metadata.
+
+<Preview>
+  <Story id="experimental-pageheader--without-background-breadcrumbitems-title" />
+</Preview>
+
+#### With status indicator
+
+Structured similarly to the examples above, this variant is for the inclusion of
+a page level status indicator.
+
+<Preview>
+  <Story id="experimental-pageheader--without-background-breadcrumbitems-title-status" />
+</Preview>
+
+### Examples with background
+
+#### With tabs
+
+Tabs are positioned underneath the page title and sit flush at the base of the
+page header background.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-title-tabs" />
+</Preview>
+
+#### With tags
+
+Tags are positioned underneath the page title and sit above the base of the page
+header background.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-title-pageactions-tags" />
+</Preview>
+
+#### With tabs & tags
+
+If both tabs & tags need to be present, tabs should be remain left aligned with
+the page and tags reposition over to the right side of the screen.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-title-tabs-tags" />
+</Preview>
+
+#### With subtitle
+
+Subtitles, if necessary, are placed directly below the page title. Page headers
+with subtitles use the background to create hierarchy and to separate it from
+type placed within the page.
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-title-pageactions-subtitle" />
+</Preview>
+
+#### With summary details
+
+Page content with global page hierarchy can be placed above tabs within the page
+header. **This is just an example of an allowable zone for content.**
+
+<Preview>
+  <Story id="experimental-pageheader--with-background-breadcrumbitems-title-pageactions-summarydetails-tabs" />
+</Preview>
+
+## Properties
+
+<Props />

--- a/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
@@ -26,10 +26,12 @@ import { PageHeader } from '.';
 
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
 
+import mdx from './PageHeader.mdx';
+
 export default {
   title: 'Experimental/PageHeader',
   component: PageHeader,
-  parameters: { styles, layout: 'fullscreen' },
+  parameters: { styles, layout: 'fullscreen', docs: { page: mdx } },
   decorators: [
     (Story) => (
       <div className="page-header-stories__viewport">
@@ -200,6 +202,17 @@ WithBackgroundBreadcrumbitemsTitleTabs.args = {
   navigation: tabBar,
 };
 
+export const WithBackgroundBreadcrumbitemsTitlePageactionsTabs = Template.bind(
+  {}
+);
+WithBackgroundBreadcrumbitemsTitlePageactionsTabs.args = {
+  background: true,
+  breadcrumbItems,
+  title,
+  pageActions,
+  navigation: tabBar,
+};
+
 export const WithBackgroundBreadcrumbitemsTitlePageactionsTags = Template.bind(
   {}
 );
@@ -218,6 +231,25 @@ WithBackgroundBreadcrumbitemsTitleTabsTags.args = {
   title,
   navigation: tabBar,
   tags,
+};
+
+export const WithBackgroundBreadcrumbitemsActionbarTitlePageactionsTabsTags = Template.bind(
+  {}
+);
+WithBackgroundBreadcrumbitemsActionbarTitlePageactionsTabsTags.args = {
+  background: true,
+  breadcrumbItems,
+  actionBarItems,
+  title,
+  pageActions,
+  navigation: tabBar,
+};
+
+export const WithBackgroundBreadcrumbitemsActionbar = Template.bind({});
+WithBackgroundBreadcrumbitemsActionbar.args = {
+  background: true,
+  breadcrumbItems,
+  actionBarItems,
 };
 
 export const WithBackgroundBreadcrumbitemsTitlePageactionsSubtitle = Template.bind(

--- a/packages/experimental-package/src/components/PageHeader/_storybook-styles.scss
+++ b/packages/experimental-package/src/components/PageHeader/_storybook-styles.scss
@@ -14,6 +14,9 @@
 .sbdocs .page-header-stories__viewport {
   overflow-y: auto;
   max-height: 500px;
+  box-shadow: 0 0 4px 1px $gray-20;
+  color: $text-01;
+  background-color: $ui-background;
 }
 
 .page-header-stories__dummy-content {


### PR DESCRIPTION
Progresses #59

Creates a custom docs page in storybook for the PageHeader

#### Changelog

M       packages/core/.storybook/addon-carbon-theme/components/Panel.js
A       packages/experimental-package/src/components/PageHeader/PageHeader.mdx
M       packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
M       packages/experimental-package/src/components/PageHeader/_storybook-styles.scss

**New**

- Custom docs page for PageHeader

