### PR TITLE
fix: negative spacing use

### DIFF
--- a/packages/experimental-package/src/components/PageHeader/_page-header.scss
+++ b/packages/experimental-package/src/components/PageHeader/_page-header.scss
@@ -32,7 +32,9 @@ $block-class: #{$exp-prefix}-page-header;
 }
 
 .#{$block-class}--action-bar {
-  margin-top: -$spacing-04; /* align with breadcrumb */
+  // stylelint-disable-next-line
+  margin-top: calc(-1 * #{$spacing-02}); /* align with breadcrumb */
+  white-space: nowrap;
   text-align: right;
 }
 


### PR DESCRIPTION
Relates to  #59

Correct -ve spacing which despite being deemed "valid" by Chrome equates to 0