### PR TITLE
feat: header to simpler wrapped buttons

### DIFF
--- a/packages/experimental-package/src/components/ExampleComponent/ExampleComponent.js
+++ b/packages/experimental-package/src/components/ExampleComponent/ExampleComponent.js
@@ -88,7 +88,7 @@ ExampleComponent.propTypes = {
    */
   onPrimaryClick: PropTypes.func,
   /**
-   * Optional secpmdaru click handler
+   * Optional secpmdary click handler
    */
   onSecondaryClick: PropTypes.func,
   /**

--- a/packages/experimental-package/src/components/ExampleComponent/ExampleComponent.js
+++ b/packages/experimental-package/src/components/ExampleComponent/ExampleComponent.js
@@ -88,7 +88,7 @@ ExampleComponent.propTypes = {
    */
   onPrimaryClick: PropTypes.func,
   /**
-   * Optional secpmdary click handler
+   * Optional secondary click handler
    */
   onSecondaryClick: PropTypes.func,
   /**

--- a/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
+++ b/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
@@ -34,13 +34,21 @@ export const ActionBarItem = (props) => {
   );
 };
 
-ActionBarItem.propTypes = {
-  /**
-   * Specifies class(es) to be applied to the top-level PageHeader node.
-   * Optional.
-   */
-  className: PropTypes.string,
-};
-ActionBarItem.defaultProps = {
-  className: '',
-};
+const reservedProps = [
+  'hasIconOnly',
+  'kind',
+  'size',
+  'tooltipPosition',
+  'tooltipAlignment',
+  'type',
+];
+const propTypes = { ...Button.propTypes };
+const defaultProps = { ...Button.defaultProps };
+
+reservedProps.forEach((prop) => {
+  delete propTypes[prop];
+  delete defaultProps[prop];
+});
+
+ActionBarItem.propTypes = { ...propTypes };
+ActionBarItem.defaultProps = { ...defaultProps };

--- a/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
+++ b/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
@@ -6,6 +6,7 @@
 //
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import cx from 'classnames';
 
@@ -33,6 +34,7 @@ export const ActionBarItem = (props) => {
   );
 };
 
+// Props the user cannot change
 const reservedProps = [
   'hasIconOnly',
   'kind',
@@ -41,13 +43,51 @@ const reservedProps = [
   'tooltipAlignment',
   'type',
 ];
+// Base props on Carbon Button
 const propTypes = { ...Button.propTypes };
 const defaultProps = { ...Button.defaultProps };
 
+// Remove reserved props
 reservedProps.forEach((prop) => {
   delete propTypes[prop];
   delete defaultProps[prop];
 });
 
-ActionBarItem.propTypes = { ...propTypes };
+ActionBarItem.propTypes = {
+  /**
+   * The ...propTypes are copies of those from Button minus the props reserved for use by this component
+   */
+  ...propTypes,
+  /* ***************************************
+  /
+  /  The declarations below allow storybook & DocGen to produce documentation.
+  /  Some or all of them may be inherited from the underlying Carbon component.
+  /
+  / ****************************************/
+  /**
+   * Specify an optional className to be added to your Button
+   *
+   * (inherited from Carbon Button)
+   */
+  className: PropTypes.string,
+  /**
+   * If specifying the `renderIcon` prop, provide a description for that icon that can
+   * be read by screen readers
+   */
+  iconDescription: PropTypes.string,
+  /**
+   * Optional click handler
+   *
+   * (inherited from Carbon Button)
+   */
+  onClick: PropTypes.func,
+  /**
+   * Optional prop to allow overriding the icon rendering.
+   * Can be a React component class
+   *
+   * (inherited from Carbon Button)
+   */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};
+
 ActionBarItem.defaultProps = { ...defaultProps };

--- a/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
+++ b/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
@@ -6,7 +6,6 @@
 //
 
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import cx from 'classnames';
 

--- a/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
+++ b/packages/experimental-package/src/components/PageHeader/ActionBarItem.js
@@ -73,6 +73,8 @@ ActionBarItem.propTypes = {
   /**
    * If specifying the `renderIcon` prop, provide a description for that icon that can
    * be read by screen readers
+   *
+   * (inherited from Carbon Button)
    */
   iconDescription: PropTypes.string,
   /**

--- a/packages/experimental-package/src/components/PageHeader/ActionBarItem.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/ActionBarItem.stories.js
@@ -18,7 +18,7 @@ export default {
   parameters: { styles },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ ...args }) => {
   return <ActionBarItem {...args} />;
 };
 

--- a/packages/experimental-package/src/components/PageHeader/ActionBarItem.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/ActionBarItem.stories.js
@@ -1,0 +1,29 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+import React from 'react';
+
+import { ActionBarItem } from './ActionBarItem';
+import { Bee24 } from '@carbon/icons-react';
+
+import styles from './_index.scss'; // import index in case more files are added later.
+
+export default {
+  title: 'Experimental/PageHeaderUtility/ActionBarItem',
+  component: ActionBarItem,
+  parameters: { styles },
+};
+
+const Template = ({ label, ...args }) => {
+  return <ActionBarItem {...args} />;
+};
+
+export const Minimal = Template.bind({});
+Minimal.args = {
+  iconDescription: 'Action',
+  renderIcon: Bee24,
+};

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.js
@@ -14,9 +14,9 @@ import { expPrefix } from '../../global/js/settings';
 
 import { Button } from 'carbon-components-react';
 
-const blockClass = `${expPrefix}-action-bar-item`;
+const blockClass = `${expPrefix}-page-action-item`;
 
-export const ActionBarItem = (props) => {
+export const PageActionItem = (props) => {
   const className = cx([blockClass, props.className]);
 
   return (
@@ -24,23 +24,19 @@ export const ActionBarItem = (props) => {
       {...{
         ...props,
         className,
-        hasIconOnly: true,
-        kind: 'ghost',
         size: 'field',
-        tooltipPosition: 'bottom',
-        tooltipAlignment: 'end',
         type: 'button',
       }}></Button>
   );
 };
 
-ActionBarItem.propTypes = {
+PageActionItem.propTypes = {
   /**
    * Specifies class(es) to be applied to the top-level PageHeader node.
    * Optional.
    */
   className: PropTypes.string,
 };
-ActionBarItem.defaultProps = {
+PageActionItem.defaultProps = {
   className: '',
 };

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.js
@@ -6,12 +6,13 @@
 //
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import cx from 'classnames';
 
 import { expPrefix } from '../../global/js/settings';
 
-import { Button } from 'carbon-components-react';
+import { Button, ButtonKinds } from 'carbon-components-react';
 
 const blockClass = `${expPrefix}-page-action-item`;
 
@@ -31,14 +32,71 @@ export const PageActionItem = ({ children, ...props }) => {
   );
 };
 
+// Props the user cannot change
 const reservedProps = ['size', 'type'];
+// Base props on Carbon Button
 const propTypes = { ...Button.propTypes };
 const defaultProps = { ...Button.defaultProps };
 
+// Remove reserved props
 reservedProps.forEach((prop) => {
   delete propTypes[prop];
   delete defaultProps[prop];
 });
 
-PageActionItem.propTypes = { ...propTypes };
+PageActionItem.propTypes = {
+  /**
+   * The ...propTypes are copies of those from Button minus the props reserved for use by this component
+   */
+  ...propTypes,
+  /* ***************************************
+  /
+  /  The declarations below allow storybook & DocGen to produce documentation.
+  /  Some or all of them may be inherited from the underlying Carbon component.
+  /
+  / ****************************************/
+  /**
+   * Specify the content of your Button
+   *
+   * (inherited from Carbon Button)
+   */
+  children: PropTypes.node,
+  /**
+   * Specify an optional className to be added to your Button
+   *
+   * (inherited from Carbon Button)
+   */
+  className: PropTypes.string,
+  /**
+   * Specify if the button is an icon-only button
+   *
+   * (inherited from Carbon Button)
+   */
+  hasIconOnly: PropTypes.bool,
+  /**
+   * If specifying the `renderIcon` prop, provide a description for that icon that can
+   * be read by screen readers
+   */
+  iconDescription: PropTypes.string,
+  /**
+   * Specify the kind of Button you want to create
+   *
+   * (inherited from Carbon Button)
+   */
+  kind: PropTypes.oneOf(ButtonKinds).isRequired,
+  /**
+   * Optional click handler
+   *
+   * (inherited from Carbon Button)
+   */
+  onClick: PropTypes.func,
+  /**
+   * Optional prop to allow overriding the icon rendering.
+   * Can be a React component class
+   *
+   * (inherited from Carbon Button)
+   */
+  renderIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+};
+
 PageActionItem.defaultProps = { ...defaultProps };

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.js
@@ -76,6 +76,8 @@ PageActionItem.propTypes = {
   /**
    * If specifying the `renderIcon` prop, provide a description for that icon that can
    * be read by screen readers
+   *
+   * (inherited from Carbon Button)
    */
   iconDescription: PropTypes.string,
   /**

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.js
@@ -6,7 +6,6 @@
 //
 
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import cx from 'classnames';
 

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.js
@@ -16,7 +16,7 @@ import { Button } from 'carbon-components-react';
 
 const blockClass = `${expPrefix}-page-action-item`;
 
-export const PageActionItem = (props) => {
+export const PageActionItem = ({ children, ...props }) => {
   const className = cx([blockClass, props.className]);
 
   return (
@@ -26,17 +26,20 @@ export const PageActionItem = (props) => {
         className,
         size: 'field',
         type: 'button',
-      }}></Button>
+      }}>
+      {children}
+    </Button>
   );
 };
 
-PageActionItem.propTypes = {
-  /**
-   * Specifies class(es) to be applied to the top-level PageHeader node.
-   * Optional.
-   */
-  className: PropTypes.string,
-};
-PageActionItem.defaultProps = {
-  className: '',
-};
+const reservedProps = ['size', 'type'];
+const propTypes = { ...Button.propTypes };
+const defaultProps = { ...Button.defaultProps };
+
+reservedProps.forEach((prop) => {
+  delete propTypes[prop];
+  delete defaultProps[prop];
+});
+
+PageActionItem.propTypes = { ...propTypes };
+PageActionItem.defaultProps = { ...defaultProps };

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.stories.js
@@ -1,0 +1,43 @@
+//
+// Copyright IBM Corp. 2020, 2020
+//
+// This source code is licensed under the Apache-2.0 license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+import React from 'react';
+
+import { PageActionItem } from './PageActionItem';
+import { Bee24 } from '@carbon/icons-react';
+
+import styles from './_index.scss'; // import index in case more files are added later.
+
+export default {
+  title: 'Experimental/PageHeaderUtility/PageActionItem',
+  component: PageActionItem,
+  parameters: { styles },
+  argTypes: {
+    kind: {
+      control: {
+        type: 'select',
+        options: {
+          'Primary button (primary)': 'primary',
+          'Secondary button (secondary)': 'secondary',
+          'Tertiary button (tertiary)': 'tertiary',
+          'Danger button (danger)': 'danger',
+          'Ghost button (ghost)': 'ghost',
+        },
+      },
+    },
+  },
+};
+
+const Template = ({ content, ...args }) => {
+  return <PageActionItem {...args}>{content}</PageActionItem>;
+};
+
+export const Minimal = Template.bind({});
+Minimal.args = {
+  content: 'Button label',
+  renderIcon: Bee24,
+};

--- a/packages/experimental-package/src/components/PageHeader/PageActionItem.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageActionItem.stories.js
@@ -32,12 +32,13 @@ export default {
   },
 };
 
-const Template = ({ content, ...args }) => {
-  return <PageActionItem {...args}>{content}</PageActionItem>;
+const Template = (argsIn) => {
+  const { children, ...args } = { ...argsIn };
+  return <PageActionItem {...args}>{children}</PageActionItem>;
 };
 
 export const Minimal = Template.bind({});
 Minimal.args = {
-  content: 'Button label',
+  children: 'Button label',
   renderIcon: Bee24,
 };

--- a/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
@@ -163,22 +163,22 @@ const summaryDetails = (
 );
 const tabBar = (
   <Tabs>
-    <Tab iconDescription="Tab 1" />
-    <Tab iconDescription="Tab 2" />
-    <Tab iconDescription="Tab 3" />
-    <Tab iconDescription="Tab 4" />
+    <Tab label="Tab 1" />
+    <Tab label="Tab 2" />
+    <Tab label="Tab 3" />
+    <Tab label="Tab 4" />
   </Tabs>
 );
 const longTabBar = (
   <Tabs>
-    <Tab iconDescription="Tab 1" />
-    <Tab iconDescription="Tab 2" />
-    <Tab iconDescription="Tab 3" />
-    <Tab iconDescription="Tab 4" />
-    <Tab iconDescription="Tab 5" />
-    <Tab iconDescription="Tab 6" />
-    <Tab iconDescription="Tab 7" />
-    <Tab iconDescription="Tab 8" />
+    <Tab label="Tab 1" />
+    <Tab label="Tab 2" />
+    <Tab label="Tab 3" />
+    <Tab label="Tab 4" />
+    <Tab label="Tab 5" />
+    <Tab label="Tab 6" />
+    <Tab label="Tab 7" />
+    <Tab label="Tab 8" />
   </Tabs>
 );
 const tags = (

--- a/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
+++ b/packages/experimental-package/src/components/PageHeader/PageHeader.stories.js
@@ -10,7 +10,6 @@ import React from 'react';
 
 import {
   BreadcrumbItem,
-  Button,
   Column,
   ContentSwitcher,
   Grid,
@@ -24,6 +23,7 @@ import { CheckmarkFilled16 } from '@carbon/icons-react';
 import { Lightning16, Bee24 } from '@carbon/icons-react';
 
 import { ActionBarItem } from './ActionBarItem';
+import { PageActionItem } from './PageActionItem';
 import { PageHeader } from '.';
 
 import styles from './_storybook-styles.scss'; // import index in case more files are added later.
@@ -35,6 +35,7 @@ export default {
   component: PageHeader,
   subcomponents: {
     ActionBarItem,
+    PageActionItem,
   },
   parameters: { styles, layout: 'fullscreen', docs: { page: mdx } },
   decorators: [
@@ -46,24 +47,24 @@ export default {
 
 const actionBarItems = (
   <>
-    <ActionBarItem icon={Lightning16} label="Action 1" />
-    <ActionBarItem icon={Lightning16} label="Action 2" />
-    <ActionBarItem icon={Lightning16} label="Action 3" />
-    <ActionBarItem icon={Lightning16} label="Action 4" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 1" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 2" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 3" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 4" />
   </>
 );
 const manyActionBarItems = (
   <>
-    <ActionBarItem icon={Lightning16} label="Action 1" />
-    <ActionBarItem icon={Lightning16} label="Action 2" />
-    <ActionBarItem icon={Lightning16} label="Action 3" />
-    <ActionBarItem icon={Lightning16} label="Action 4" />
-    <ActionBarItem icon={Lightning16} label="Action 5" />
-    <ActionBarItem icon={Lightning16} label="Action 6" />
-    <ActionBarItem icon={Lightning16} label="Action 7" />
-    <ActionBarItem icon={Lightning16} label="Action 8" />
-    <ActionBarItem icon={Lightning16} label="Action 9" />
-    <ActionBarItem icon={Lightning16} label="Action 10" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 1" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 2" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 3" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 4" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 5" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 6" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 7" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 8" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 9" />
+    <ActionBarItem renderIcon={Lightning16} iconDescription="Action 10" />
   </>
 );
 const breadcrumbItems = (
@@ -124,21 +125,15 @@ const dummyPageContent = (
 );
 const pageActions = (
   <>
-    <Button kind="secondary" size="field">
-      Secondary button
-    </Button>
-    <Button size="field">Primary button</Button>
+    <PageActionItem kind="secondary">Secondary button</PageActionItem>
+    <PageActionItem kind="primary">Primary button</PageActionItem>
   </>
 );
 const manyPageActions = (
   <>
-    <Button kind="secondary" size="field">
-      Secondary button 1
-    </Button>
-    <Button kind="secondary" size="field">
-      Secondary button 2
-    </Button>
-    <Button size="field">Primary button</Button>
+    <PageActionItem kind="secondary">Secondary button 1</PageActionItem>
+    <PageActionItem kind="secondary">Secondary button 2</PageActionItem>
+    <PageActionItem kind="primary">Primary button</PageActionItem>
   </>
 );
 const statusIndicator = (
@@ -168,22 +163,22 @@ const summaryDetails = (
 );
 const tabBar = (
   <Tabs>
-    <Tab label="Tab 1" />
-    <Tab label="Tab 2" />
-    <Tab label="Tab 3" />
-    <Tab label="Tab 4" />
+    <Tab iconDescription="Tab 1" />
+    <Tab iconDescription="Tab 2" />
+    <Tab iconDescription="Tab 3" />
+    <Tab iconDescription="Tab 4" />
   </Tabs>
 );
 const longTabBar = (
   <Tabs>
-    <Tab label="Tab 1" />
-    <Tab label="Tab 2" />
-    <Tab label="Tab 3" />
-    <Tab label="Tab 4" />
-    <Tab label="Tab 5" />
-    <Tab label="Tab 6" />
-    <Tab label="Tab 7" />
-    <Tab label="Tab 8" />
+    <Tab iconDescription="Tab 1" />
+    <Tab iconDescription="Tab 2" />
+    <Tab iconDescription="Tab 3" />
+    <Tab iconDescription="Tab 4" />
+    <Tab iconDescription="Tab 5" />
+    <Tab iconDescription="Tab 6" />
+    <Tab iconDescription="Tab 7" />
+    <Tab iconDescription="Tab 8" />
   </Tabs>
 );
 const tags = (


### PR DESCRIPTION
Part of  #59

Utility components PageAction and ActionBarItem simplified to wrap button. These are restricted UI types specified by the design.

#### Changelog

Use the following command to list changes or manually list out new, changed and
removed files.

M       packages/experimental-package/src/components/ExampleComponent/ExampleComponent.js
M       packages/experimental-package/src/components/PageHeader/ActionBarItem.js
A       packages/experimental-package/src/components/PageHeader/ActionBarItem.stories.js
A       packages/experimental-package/src/components/PageHeader/PageActionItem.js
A       packages/experimental-package/src/components/PageHeader/PageActionItem.stories.js
M       packages/experimental-package/src/components/PageHeader/PageHeader.stories.js

#### Testing / Reviewing

Verified still working in the storybook. Ran linter and tests.