### PR TITLE
chore: restrict linting to exclude built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "format": "prettier --write '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**'",
     "format:diff": "prettier --list-different '**/*.{js,md,mdx,scss,ts}' '!**/{build,es,lib,storybook,ts,umd}/**'",
     "lint": "yarn lint:es && yarn lint:style",
-    "lint:es": "eslint 'packages/**/*.js'",
-    "lint:style": "stylelint 'packages/**/*.scss' --report-needless-disables --report-invalid-scope-disables",
+    "lint:es": "eslint 'packages/*/src/**/*.js'",
+    "lint:style": "stylelint 'packages/*/src/**/*.scss' --report-needless-disables --report-invalid-scope-disables",
     "test": "jest",
     "storybook": "cd packages/core && yarn start",
     "sync": "carbon-cli sync"


### PR DESCRIPTION
Files built and/or copied by builds should not be linted.

#### Changelog

The CDAI package copies SCSS files rather than compile to css, this results in double linting of these files.

Changed the blob for stylelint and eslint to target only `package/*/src/**` files.

M       package.json

#### Testing / Reviewing

Added and then removed eslint and errors to check both stylelint and eslint function as expected.
